### PR TITLE
feat: possibility to set theme in PaperProvider

### DIFF
--- a/src/Paper__PaperProvider.re
+++ b/src/Paper__PaperProvider.re
@@ -1,2 +1,5 @@
 [@bs.module "react-native-paper"] [@react.component]
-external make: (~children: React.element) => React.element = "Provider";
+external make:
+  (~children: React.element, ~theme: Paper__ThemeProvider.Theme.t=?) =>
+  React.element =
+  "Provider";

--- a/src/Paper__ThemeProvider.re
+++ b/src/Paper__ThemeProvider.re
@@ -48,6 +48,14 @@ module Theme = {
       (~regular: font, ~medium: font, ~light: font, ~thin: font) => t;
   };
 
+  module Animation = {
+    type t;
+
+    [@bs.obj] external make: (~scale: float) => t;
+
+    [@bs.get] external scale: t => float = "scale";
+  };
+
   [@bs.obj]
   external make:
     (
@@ -55,12 +63,14 @@ module Theme = {
       ~dark: bool=?,
       ~colors: Colors.t=?,
       ~fonts: Fonts.configured=?,
+      ~animation: Animation.t=?,
       unit
     ) =>
     t;
 
   [@bs.get] external fonts: t => Fonts.configured = "fonts";
   [@bs.get] external colors: t => Colors.t = "colors";
+  [@bs.get] external animation: t => Animation.t = "animation";
   [@bs.get] external dark: t => bool = "dark";
 };
 


### PR DESCRIPTION
This PR adds a possibility to pass the default theme in PaperProvider. See the original [Paper docs](https://callstack.github.io/react-native-paper/theming.html).

In addition to that I added missing `animation` theme property.

After those changes it is for example possible to create a theme based on a default one. Just like this:

```re
// Theming.re
let theme =
  ThemeProvider.(
    Theme.make(
      ~colors=
        Theme.Colors.make(
          ~primary="red",
          ~accent="blue",
          ~background=defaultTheme->Theme.colors->Theme.Colors.background,
          ~surface=defaultTheme->Theme.colors->Theme.Colors.surface,
          ~error=defaultTheme->Theme.colors->Theme.Colors.error,
          ~text="black",
          ~disabled=defaultTheme->Theme.colors->Theme.Colors.disabled,
          ~placeholder=defaultTheme->Theme.colors->Theme.Colors.placeholder,
          ~backdrop=defaultTheme->Theme.colors->Theme.Colors.backdrop,
        ),
      ~fonts=defaultTheme->Theme.fonts,
      ~roundness=4,
      ~dark=false,
      ~animation=defaultTheme->Theme.animation,
      (),
    )
  );
```

and use it like this:

```re
// App.re
<Paper.PaperProvider theme=Theming.theme>
   <YourApp />
</Paper.PaperProvider>
```