### PR TITLE
Use correct package name in bsconfig.json

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-paper",
+  "name": "@reason-react-native/paper",
   "refmt": 3,
   "reason": {
     "react-jsx": 3


### PR DESCRIPTION
### Issue
- Unable to install `@reason-react-native/paper` due to incorrect package name in `bsconfig.json` file. 
- Error recieved: `Error: package name is expected to be @reason-react-native/paper but got react-native-paper`

### Fix
I updated the name of the package to be `@reason-react-native/paper`