### PR TITLE
Add Icon and Afix bindings for TextInput

### DIFF
--- a/src/Paper__TextInput.res
+++ b/src/Paper__TextInput.res
@@ -1,3 +1,12 @@
+module Icon = {
+  @module("react-native-paper") @scope("TextInput") @react.component
+  external make: (~name: Paper__Icon.t, ~color: string=?) => React.element = "Icon"
+}
+module Affix = {
+  @module("react-native-paper") @scope("TextInput") @react.component
+  external make: (~text: string) => React.element = "Affix"
+}
+
 @module("react-native-paper") @react.component
 external make: (
   ~mode: [#flat | #outlined],
@@ -55,4 +64,5 @@ external make: (
   ~onBlur: unit => unit=?,
   ~testID: string=?,
   ~ref: Js.Nullable.t<'a> => unit=?,
+  ~right: React.element=?,
 ) => React.element = "TextInput"


### PR DESCRIPTION
Add bindings for [afix](https://callstack.github.io/react-native-paper/text-input-affix.html) and [icon](https://callstack.github.io/react-native-paper/text-input-icon.html) on `TextInput`

Validated on React Native Paper 4.12.4

